### PR TITLE
fix: 修复url正则无法正确识别转义后的&

### DIFF
--- a/lib/ui/widget/ref_view.dart
+++ b/lib/ui/widget/ref_view.dart
@@ -48,8 +48,9 @@ class _RefViewState extends State<RefView> with SingleTickerProviderStateMixin {
 
   // 匹配http url，但不能是<a href=“打头的，否则会破坏原有的html跳转标签
   // 可以保证用户输入的'<'会被转义成‘&lt;’，所以没有误解析用户输入的风险
+  // '&' 会被转义成 '&amp;'，需要特别处理
   static final RegExp httpUrlPattern = RegExp(
-      r'(?<!<a href=")https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)');
+      r'(?<!<a href=")https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b((?:[-a-zA-Z0-9()@:%_\+.~#?//=]|&amp;)*)');
 
   late Future<RefHtml> _futureReply;
   bool _isCollapsed = true;

--- a/lib/ui/widget/reply_item.dart
+++ b/lib/ui/widget/reply_item.dart
@@ -20,8 +20,9 @@ class ReplyItem extends StatelessWidget {
 
   // 匹配http url，但不能是<a href=“打头的，否则会破坏原有的html跳转标签
   // 可以保证用户输入的'<'会被转义成‘&lt;’，所以没有误解析用户输入的风险
+  // '&' 会被转义成 '&amp;'，需要特别处理
   static final RegExp httpUrlPattern = RegExp(
-      r'(?<!<a href=")https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)');
+      r'(?<!<a href=")https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b((?:[-a-zA-Z0-9()@:%_\+.~#?//=]|&amp;)*)');
 
   final ReplyJson threadJson;
   final Object? contentHeroTag;


### PR DESCRIPTION
‘&’ 会在 api 中转义为 ‘&amp;’